### PR TITLE
humanized durations

### DIFF
--- a/client/config.js
+++ b/client/config.js
@@ -2,8 +2,9 @@
 
 var path = require('path');
 require('dotenv').load({path: path.join(__dirname, '.env')});
-var ttl = +process.env.TTL || 1000 * 15;
+var ttl = process.env.TTL || ('' + (1000 * 15));
 var boolean = require('boolean');
+var duration = require('parse-duration');
 var uuids = {
   sensortag: deviceUuids('sensortag'),
   minew: deviceUuids('minew'),
@@ -24,17 +25,17 @@ module.exports = {
   rpi: boolean(process.env.RPI),
   dummy: boolean(process.env.DUMMY),
   sensortag: {
-    ttl: +process.env.SENSORTAG_TTL || ttl,
+    ttl: duration(process.env.SENSORTAG_TTL || ttl),
     enabled: uuids.sensortag.length || enabled.sensortag,
     uuids: uuids.sensortag
   },
   minew: {
-    ttl: +process.env.MINEW_TTL || ttl,
+    ttl: duration(process.env.MINEW_TTL || ttl),
     enabled: uuids.minew.length || enabled.minew,
     uuids: uuids.minew
   },
   flowerPowerCloud: {
-    ttl: +process.env.FLOWER_POWER_CLOUD_TTL || ttl,
+    ttl: duration(process.env.FLOWER_POWER_CLOUD_TTL || ttl),
     clientId: process.env.FLOWER_POWER_CLOUD_CLIENT_ID,
     clientSecret: process.env.FLOWER_POWER_CLOUD_CLIENT_SECRET,
     username: process.env.FLOWER_POWER_CLOUD_USERNAME,
@@ -43,12 +44,12 @@ module.exports = {
     enabled: enabled.flowerPowerCloud
   },
   flowerPower: {
-    ttl: +process.env.FLOWER_POWER_TTL || ttl,
+    ttl: duration(process.env.FLOWER_POWER_TTL || ttl),
     enabled: uuids.flowerPower.length || enabled.flowerPower,
     uuids: uuids.flowerPower
   },
   flowerPowerHistory: {
-    ttl: +process.env.FLOWER_POWER_HISTORY_TTL || ttl,
+    ttl: duration(process.env.FLOWER_POWER_HISTORY_TTL || ttl),
     enabled: uuids.flowerPowerHistory.length || enabled.flowerPowerHistory,
     uuids: uuids.flowerPowerHistory,
     clientId: process.env.FLOWER_POWER_CLOUD_CLIENT_ID,
@@ -61,12 +62,12 @@ module.exports = {
     key: process.env.WEATHER_KEY,
     location: process.env.WEATHER_LOCATION,
     enabled: process.env.WEATHER_KEY && process.env.WEATHER_LOCATION,
-    ttl: +process.env.WEATHER_TTL || ttl
+    ttl: duration(process.env.WEATHER_TTL || ttl)
   },
   uptime: {
     enabled: enabled.uptime,
     service: process.env.UPTIME_SERVICE,
-    ttl: +process.env.UPTIME_TTL || ttl
+    ttl: duration(process.env.UPTIME_TTL || ttl)
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "noble-device": "^1.2.0",
     "nodemailer": "^1.5.0",
     "nodemailer-smtp-transport": "^1.0.3",
+    "parse-duration": "^0.1.1",
     "proxyquire": "^1.6.0",
     "request": "^2.54.0",
     "run-series": "^1.1.1",


### PR DESCRIPTION
ablity to do such a thing: `TTL=60s node client/` instead of `TTL=60000 node client/` which is kinda hard to read and with bigger numbers it's getting way more harder to convert them. :/